### PR TITLE
Use default modules path as fallback

### DIFF
--- a/src/angular_metadata_generator.js
+++ b/src/angular_metadata_generator.js
@@ -3,44 +3,61 @@
 const { sanitizeName, sanitizeClassName } = require("./helpers");
 
 function generate(metadata, options) {
-  let angularIndexPath = undefined;
+  let angularIndexPath;
+  let defaultImplementationPath;
   if (options.angularMappings) {
+    defaultImplementationPath = options.angularMappings.defaultModulesPath;
     angularIndexPath = options.angularMappings.angularIndexPath;
   }
 
-  let includeUnavailableProperties = (options.notImplementedSettings !== undefined && options.notImplementedSettings.doNotGenerateClasses === true);
+  let includeUnavailableProperties =
+    options.notImplementedSettings !== undefined &&
+    options.notImplementedSettings.doNotGenerateClasses === true;
 
   if (metadata.definitions) {
     const output = metadata.definitions.map(def => {
       const isImplemented = def.isImplemented;
       let impPath = def.implementationPath;
       let genClass = isImplemented ? impPath !== undefined : def.generateClass;
-
+      if (!impPath) {
+        impPath = defaultImplementationPath;
+      }
       return {
         name: def.name,
         generatesClass: genClass,
         externalName: genClass ? sanitizeClassName(def.name) : undefined,
-        externalModuleName: genClass ? angularIndexPath : undefined,
+        externalModuleName: genClass ? angularIndexPath || impPath : undefined,
         methods: def.methods
           ? def.methods.map(meth => {
-            return {
-              name: meth.name,
-              implementationName: meth.implementationName ? meth.implementationName : sanitizeName(meth.name),
-              externalName: meth.implementationAlias ? meth.implementationAlias : sanitizeName(meth.name),
-              externalModuleName: genClass ? undefined : angularIndexPath,
-              isStatic: meth.static ? true : undefined,
-              notifiesGenerator: meth.notifiesGenerator ? true : undefined
-            };
-          })
+              let methImpPath = meth.implementationPath
+                ? meth.implementationPath
+                : defaultImplementationPath;
+              return {
+                name: meth.name,
+                implementationName: meth.implementationName
+                  ? meth.implementationName
+                  : sanitizeName(meth.name),
+                externalName: meth.implementationAlias
+                  ? meth.implementationAlias
+                  : sanitizeName(meth.name),
+                externalModuleName: genClass
+                  ? undefined
+                  : angularIndexPath || methImpPath,
+                isStatic: meth.static ? true : undefined,
+                notifiesGenerator: meth.notifiesGenerator ? true : undefined
+              };
+            })
           : undefined,
-        properties: def.properties !== undefined && includeUnavailableProperties
-          ? def.properties.map(prop => {
-            return {
-              name: prop.name,
-              unavailable: (prop.unavailable !== undefined) ? prop.unavailable : true
-            }
-          })
-          : undefined
+        properties:
+          def.properties !== undefined && includeUnavailableProperties
+            ? def.properties.map(prop => {
+                return {
+                  name: prop.name,
+                  unavailable:
+                    prop.unavailable !== undefined ? prop.unavailable : true
+                };
+              })
+            : undefined
       };
     });
     return JSON.stringify({ modules: output });


### PR DESCRIPTION
When no implementation path is specified, use the defaultModulesPath